### PR TITLE
Add DDEV support in session start hook

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -15,24 +15,24 @@ SKILL_DIR="${PLUGIN_ROOT}/skills/using-symfony-superpowers"
 # ============================================
 
 detect_symfony_apps() {
-    local search_root="${1:-.}"
-    local apps=()
+  local search_root="${1:-.}"
+  local apps=()
 
-    # Search for composer.json with symfony/framework-bundle
-    while IFS= read -r -d '' composer_file; do
-        if grep -q '"symfony/framework-bundle"' "$composer_file" 2>/dev/null; then
-            local app_dir
-            app_dir=$(dirname "$composer_file")
-            apps+=("$app_dir")
-        fi
-    done < <(find "$search_root" \
-        -name "composer.json" \
-        -not -path "*/vendor/*" \
-        -not -path "*/node_modules/*" \
-        -not -path "*/.git/*" \
-        -print0 2>/dev/null)
+  # Search for composer.json with symfony/framework-bundle
+  while IFS= read -r -d '' composer_file; do
+    if grep -q '"symfony/framework-bundle"' "$composer_file" 2>/dev/null; then
+      local app_dir
+      app_dir=$(dirname "$composer_file")
+      apps+=("$app_dir")
+    fi
+  done < <(find "$search_root" \
+    -name "composer.json" \
+    -not -path "*/vendor/*" \
+    -not -path "*/node_modules/*" \
+    -not -path "*/.git/*" \
+    -print0 2>/dev/null)
 
-    printf '%s\n' "${apps[@]}"
+  printf '%s\n' "${apps[@]}"
 }
 
 # ============================================
@@ -40,23 +40,23 @@ detect_symfony_apps() {
 # ============================================
 
 get_symfony_version() {
-    local app_dir="$1"
-    local version=""
+  local app_dir="$1"
+  local version=""
 
-    # Priority 1: composer.lock (most accurate)
-    if [[ -f "$app_dir/composer.lock" ]]; then
-        version=$(grep -A5 '"name": "symfony/framework-bundle"' "$app_dir/composer.lock" 2>/dev/null | \
-            grep '"version"' | head -1 | \
-            sed -E 's/.*"version": "v?([0-9]+\.[0-9]+).*/\1/')
-    fi
+  # Priority 1: composer.lock (most accurate)
+  if [[ -f "$app_dir/composer.lock" ]]; then
+    version=$(grep -A5 '"name": "symfony/framework-bundle"' "$app_dir/composer.lock" 2>/dev/null |
+      grep '"version"' | head -1 |
+      sed -E 's/.*"version": "v?([0-9]+\.[0-9]+).*/\1/')
+  fi
 
-    # Priority 2: composer.json require
-    if [[ -z "$version" && -f "$app_dir/composer.json" ]]; then
-        version=$(grep '"symfony/framework-bundle"' "$app_dir/composer.json" 2>/dev/null | \
-            sed -E 's/.*"[\^~]?([0-9]+\.[0-9]+).*/\1/')
-    fi
+  # Priority 2: composer.json require
+  if [[ -z "$version" && -f "$app_dir/composer.json" ]]; then
+    version=$(grep '"symfony/framework-bundle"' "$app_dir/composer.json" 2>/dev/null |
+      sed -E 's/.*"[\^~]?([0-9]+\.[0-9]+).*/\1/')
+  fi
 
-    echo "${version:-unknown}"
+  echo "${version:-unknown}"
 }
 
 # ============================================
@@ -64,24 +64,24 @@ get_symfony_version() {
 # ============================================
 
 detect_api_platform() {
-    local app_dir="$1"
-    local has_api_platform="false"
-    local api_version=""
+  local app_dir="$1"
+  local has_api_platform="false"
+  local api_version=""
 
-    if [[ -f "$app_dir/composer.lock" ]]; then
-        if grep -q '"api-platform/core"' "$app_dir/composer.lock" 2>/dev/null; then
-            has_api_platform="true"
-            api_version=$(grep -A5 '"name": "api-platform/core"' "$app_dir/composer.lock" 2>/dev/null | \
-                grep '"version"' | head -1 | \
-                sed -E 's/.*"version": "v?([0-9]+\.[0-9]+).*/\1/')
-        fi
-    elif [[ -f "$app_dir/composer.json" ]]; then
-        if grep -q '"api-platform/core"' "$app_dir/composer.json" 2>/dev/null; then
-            has_api_platform="true"
-        fi
+  if [[ -f "$app_dir/composer.lock" ]]; then
+    if grep -q '"api-platform/core"' "$app_dir/composer.lock" 2>/dev/null; then
+      has_api_platform="true"
+      api_version=$(grep -A5 '"name": "api-platform/core"' "$app_dir/composer.lock" 2>/dev/null |
+        grep '"version"' | head -1 |
+        sed -E 's/.*"version": "v?([0-9]+\.[0-9]+).*/\1/')
     fi
+  elif [[ -f "$app_dir/composer.json" ]]; then
+    if grep -q '"api-platform/core"' "$app_dir/composer.json" 2>/dev/null; then
+      has_api_platform="true"
+    fi
+  fi
 
-    echo "${has_api_platform}:${api_version:-none}"
+  echo "${has_api_platform}:${api_version:-none}"
 }
 
 # ============================================
@@ -89,34 +89,37 @@ detect_api_platform() {
 # ============================================
 
 detect_docker_type() {
-    local app_dir="$1"
-    local docker_type="none"
+  local app_dir="$1"
+  local docker_type="none"
 
-    # Check for Symfony Docker (dunglas/symfony-docker with FrankenPHP)
-    if [[ -f "$app_dir/compose.yaml" ]]; then
-        if grep -qE "(frankenphp|dunglas/symfony-docker|caddy)" "$app_dir/compose.yaml" 2>/dev/null; then
-            docker_type="symfony-docker"
-        elif grep -q "services:" "$app_dir/compose.yaml" 2>/dev/null; then
-            docker_type="compose-yaml"
-        fi
-    elif [[ -f "$app_dir/compose.yml" ]]; then
-        if grep -qE "(frankenphp|dunglas/symfony-docker|caddy)" "$app_dir/compose.yml" 2>/dev/null; then
-            docker_type="symfony-docker"
-        else
-            docker_type="compose-yml"
-        fi
-    elif [[ -f "$app_dir/docker-compose.yaml" ]]; then
-        docker_type="docker-compose-yaml"
-    elif [[ -f "$app_dir/docker-compose.yml" ]]; then
-        docker_type="docker-compose-yml"
+  # Check for DDEV first (highest priority)
+  if [[ -d "$app_dir/.ddev" ]]; then
+    docker_type="ddev"
+  # Check for Symfony Docker (dunglas/symfony-docker with FrankenPHP)
+  elif [[ -f "$app_dir/compose.yaml" ]]; then
+    if grep -qE "(frankenphp|dunglas/symfony-docker|caddy)" "$app_dir/compose.yaml" 2>/dev/null; then
+      docker_type="symfony-docker"
+    elif grep -q "services:" "$app_dir/compose.yaml" 2>/dev/null; then
+      docker_type="compose-yaml"
     fi
-
-    # Additional check for Symfony Docker indicators
-    if [[ -d "$app_dir/frankenphp" ]] || [[ -f "$app_dir/Caddyfile" ]]; then
-        docker_type="symfony-docker"
+  elif [[ -f "$app_dir/compose.yml" ]]; then
+    if grep -qE "(frankenphp|dunglas/symfony-docker|caddy)" "$app_dir/compose.yml" 2>/dev/null; then
+      docker_type="symfony-docker"
+    else
+      docker_type="compose-yml"
     fi
+  elif [[ -f "$app_dir/docker-compose.yaml" ]]; then
+    docker_type="docker-compose-yaml"
+  elif [[ -f "$app_dir/docker-compose.yml" ]]; then
+    docker_type="docker-compose-yml"
+  fi
 
-    echo "$docker_type"
+  # Additional check for Symfony Docker indicators
+  if [[ -d "$app_dir/frankenphp" ]] || [[ -f "$app_dir/Caddyfile" ]]; then
+    docker_type="symfony-docker"
+  fi
+
+  echo "$docker_type"
 }
 
 # ============================================
@@ -124,28 +127,31 @@ detect_docker_type() {
 # ============================================
 
 check_docker_running() {
-    local app_dir="$1"
-    local docker_type="$2"
+  local app_dir="$1"
+  local docker_type="$2"
 
-    # For testing
-    if [[ "${SUPERPOWERS_TEST_DOCKER_RUNNING:-}" == "true" ]]; then
-        echo "true"
-        return
-    fi
+  # For testing
+  if [[ "${SUPERPOWERS_TEST_DOCKER_RUNNING:-}" == "true" ]]; then
+    echo "true"
+    return
+  fi
 
-    if ! command -v docker &>/dev/null; then
-        echo "false"
-        return
-    fi
+  if ! command -v docker &>/dev/null; then
+    echo "false"
+    return
+  fi
 
-    # Check if containers are running in project context
-    cd "$app_dir" 2>/dev/null || { echo "false"; return; }
+  # Check if containers are running in project context
+  cd "$app_dir" 2>/dev/null || {
+    echo "false"
+    return
+  }
 
-    if docker compose ps --filter "status=running" 2>/dev/null | grep -q .; then
-        echo "true"
-    else
-        echo "false"
-    fi
+  if docker compose ps --filter "status=running" 2>/dev/null | grep -q .; then
+    echo "true"
+  else
+    echo "false"
+  fi
 }
 
 # ============================================
@@ -153,20 +159,20 @@ check_docker_running() {
 # ============================================
 
 detect_test_framework() {
-    local app_dir="$1"
-    local framework="phpunit"  # Default Symfony
+  local app_dir="$1"
+  local framework="phpunit" # Default Symfony
 
-    if [[ -f "$app_dir/composer.lock" ]]; then
-        if grep -q '"pestphp/pest"' "$app_dir/composer.lock" 2>/dev/null; then
-            framework="pest"
-        fi
-    elif [[ -f "$app_dir/composer.json" ]]; then
-        if grep -q '"pestphp/pest"' "$app_dir/composer.json" 2>/dev/null; then
-            framework="pest"
-        fi
+  if [[ -f "$app_dir/composer.lock" ]]; then
+    if grep -q '"pestphp/pest"' "$app_dir/composer.lock" 2>/dev/null; then
+      framework="pest"
     fi
+  elif [[ -f "$app_dir/composer.json" ]]; then
+    if grep -q '"pestphp/pest"' "$app_dir/composer.json" 2>/dev/null; then
+      framework="pest"
+    fi
+  fi
 
-    echo "$framework"
+  echo "$framework"
 }
 
 # ============================================
@@ -174,36 +180,41 @@ detect_test_framework() {
 # ============================================
 
 get_runner_commands() {
-    local app_dir="$1"
-    local docker_type="$2"
-    local docker_running="$3"
+  local app_dir="$1"
+  local docker_type="$2"
+  local docker_running="$3"
 
-    local runner_cmd="php"
-    local console_cmd="php bin/console"
-    local composer_cmd="composer"
-    local test_cmd="./vendor/bin/phpunit"
+  local runner_cmd="php"
+  local console_cmd="php bin/console"
+  local composer_cmd="composer"
+  local test_cmd="./vendor/bin/phpunit"
 
-    if [[ "$docker_running" == "true" ]]; then
-        if [[ "$docker_type" == "symfony-docker" ]]; then
-            runner_cmd="docker compose exec php"
-            console_cmd="docker compose exec php bin/console"
-            composer_cmd="docker compose exec php composer"
-            test_cmd="docker compose exec php ./vendor/bin/phpunit"
-        elif [[ "$docker_type" != "none" ]]; then
-            # Docker Compose standard - detect service name
-            local service_name="php"
-            cd "$app_dir" 2>/dev/null || true
-            if docker compose config --services 2>/dev/null | grep -q "^app$"; then
-                service_name="app"
-            fi
-            runner_cmd="docker compose exec $service_name"
-            console_cmd="docker compose exec $service_name bin/console"
-            composer_cmd="docker compose exec $service_name composer"
-            test_cmd="docker compose exec $service_name ./vendor/bin/phpunit"
-        fi
+  if [[ "$docker_running" == "true" ]]; then
+    if [[ "$docker_type" == "ddev" ]]; then
+      runner_cmd="ddev exec"
+      console_cmd="ddev exec bin/console"
+      composer_cmd="ddev composer"
+      test_cmd="ddev exec ./vendor/bin/phpunit"
+    elif [[ "$docker_type" == "symfony-docker" ]]; then
+      runner_cmd="docker compose exec php"
+      console_cmd="docker compose exec php bin/console"
+      composer_cmd="docker compose exec php composer"
+      test_cmd="docker compose exec php ./vendor/bin/phpunit"
+    elif [[ "$docker_type" != "none" ]]; then
+      # Docker Compose standard - detect service name
+      local service_name="php"
+      cd "$app_dir" 2>/dev/null || true
+      if docker compose config --services 2>/dev/null | grep -q "^app$"; then
+        service_name="app"
+      fi
+      runner_cmd="docker compose exec $service_name"
+      console_cmd="docker compose exec $service_name bin/console"
+      composer_cmd="docker compose exec $service_name composer"
+      test_cmd="docker compose exec $service_name ./vendor/bin/phpunit"
     fi
+  fi
 
-    echo "${runner_cmd}|${console_cmd}|${composer_cmd}|${test_cmd}"
+  echo "${runner_cmd}|${console_cmd}|${composer_cmd}|${test_cmd}"
 }
 
 # ============================================
@@ -211,59 +222,61 @@ get_runner_commands() {
 # ============================================
 
 main() {
-    local cwd="${PWD}"
-    local apps
+  local cwd="${PWD}"
+  local apps
 
-    # Detect Symfony applications
-    mapfile -t apps < <(detect_symfony_apps "$cwd")
+  # Detect Symfony applications
+  mapfile -t apps < <(detect_symfony_apps "$cwd")
 
-    if [[ ${#apps[@]} -eq 0 ]]; then
-        # No Symfony application detected
-        exit 0
+  if [[ ${#apps[@]} -eq 0 ]]; then
+    # No Symfony application detected
+    exit 0
+  fi
+
+  # Determine active application (one in CWD or first found)
+  local active_app=""
+  for app in "${apps[@]}"; do
+    if [[ "$cwd" == "$app"* ]]; then
+      active_app="$app"
+      break
     fi
+  done
+  [[ -z "$active_app" ]] && active_app="${apps[0]}"
 
-    # Determine active application (one in CWD or first found)
-    local active_app=""
-    for app in "${apps[@]}"; do
-        if [[ "$cwd" == "$app"* ]]; then
-            active_app="$app"
-            break
-        fi
-    done
-    [[ -z "$active_app" ]] && active_app="${apps[0]}"
+  # Collect information
+  local symfony_version
+  local api_platform_info
+  local docker_type
+  local docker_running
+  local test_framework
+  local runner_info
 
-    # Collect information
-    local symfony_version
-    local api_platform_info
-    local docker_type
-    local docker_running
-    local test_framework
-    local runner_info
+  symfony_version=$(get_symfony_version "$active_app")
+  api_platform_info=$(detect_api_platform "$active_app")
+  docker_type=$(detect_docker_type "$active_app")
+  docker_running=$(check_docker_running "$active_app" "$docker_type")
+  test_framework=$(detect_test_framework "$active_app")
+  runner_info=$(get_runner_commands "$active_app" "$docker_type" "$docker_running")
 
-    symfony_version=$(get_symfony_version "$active_app")
-    api_platform_info=$(detect_api_platform "$active_app")
-    docker_type=$(detect_docker_type "$active_app")
-    docker_running=$(check_docker_running "$active_app" "$docker_type")
-    test_framework=$(detect_test_framework "$active_app")
-    runner_info=$(get_runner_commands "$active_app" "$docker_type" "$docker_running")
+  # Parse API Platform info
+  local has_api_platform="${api_platform_info%%:*}"
+  local api_version="${api_platform_info##*:}"
 
-    # Parse API Platform info
-    local has_api_platform="${api_platform_info%%:*}"
-    local api_version="${api_platform_info##*:}"
+  # Parse runner commands
+  IFS='|' read -r runner_cmd console_cmd composer_cmd test_cmd <<<"$runner_info"
 
-    # Parse runner commands
-    IFS='|' read -r runner_cmd console_cmd composer_cmd test_cmd <<< "$runner_info"
+  # Determine guidance messages
+  local guidance_docker=""
+  if [[ "$docker_type" == "ddev" && "$docker_running" == "false" ]]; then
+    guidance_docker="Start DDEV with: ddev start"
+  elif [[ "$docker_type" == "symfony-docker" && "$docker_running" == "false" ]]; then
+    guidance_docker="Start Symfony Docker with: docker compose up -d --wait"
+  elif [[ "$docker_type" != "none" && "$docker_type" != "symfony-docker" && "$docker_type" != "ddev" && "$docker_running" == "false" ]]; then
+    guidance_docker="Start Docker containers with: docker compose up -d"
+  fi
 
-    # Determine guidance messages
-    local guidance_docker=""
-    if [[ "$docker_type" == "symfony-docker" && "$docker_running" == "false" ]]; then
-        guidance_docker="Start Symfony Docker with: docker compose up -d --wait"
-    elif [[ "$docker_type" != "none" && "$docker_type" != "symfony-docker" && "$docker_running" == "false" ]]; then
-        guidance_docker="Start Docker containers with: docker compose up -d"
-    fi
-
-    # Output JSON context for Claude
-    cat <<EOF
+  # Output JSON context for Claude
+  cat <<EOF
 {
   "plugin": "superpowers-symfony",
   "detected_apps": ${#apps[@]},
@@ -292,13 +305,13 @@ main() {
 }
 EOF
 
-    # Load and output onboarding skill if available
-    if [[ -f "$SKILL_DIR/SKILL.md" ]]; then
-        echo ""
-        echo "---"
-        echo ""
-        cat "$SKILL_DIR/SKILL.md"
-    fi
+  # Load and output onboarding skill if available
+  if [[ -f "$SKILL_DIR/SKILL.md" ]]; then
+    echo ""
+    echo "---"
+    echo ""
+    cat "$SKILL_DIR/SKILL.md"
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
Hi MakFly,

thx for sharing you superpowers configuration!

I use as a development environment DDEV. So I thought I add it to your detection script - maybe others out there use DDEV, too.

```
- Detect DDEV environments
- Add DDEV-specific runner commands and startup guidance
- Enhance Docker type detection to include DDEV
```

I saw in the `diff` that I applied a different code sytle (2 spaces instead of 4 spaces). I didn't saw it before - would have changed it back.

Basically I added in the `detect_docker_type()` function the detection for `ddev` and in the `get_runner_commands()` the vars for the `*_cmd`.

Carsten
 