### PR TITLE
fix functional-tests skill frontmatter + add skill-review CI

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,14 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@14b47c8420ff9ac9a12c30ed4b89ce0e9d0355ae # main

--- a/skills/functional-tests/SKILL.md
+++ b/skills/functional-tests/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: symfony:functional-tests
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Bash
-  - Glob
-  - Grep
-description: Drive Symfony delivery with deterministic tests and strong regression protection. Use for functional tests tasks.
+allowed-tools: "Read, Write, Edit, Bash, Glob, Grep"
+description: >
+  Write and maintain Symfony functional tests using TDD (RED/GREEN/REFACTOR).
+  Converts bug reports into failing tests, builds regression-safe behavior,
+  and validates HTTP responses, form submissions, and authorization flows.
+  Use when the user asks to write functional tests, add test coverage, convert
+  a bug into a test, or set up TDD workflow for Symfony controllers and endpoints.
 ---
 
 # Functional Tests (Symfony)


### PR DESCRIPTION
hey @MakFly, thanks for building superpowers-symfony. really like the breadth of Symfony skills you've put together in one place. Kudos on soon reaching `100` stars! I've just starred it.

ran your functional-tests skill through agent evals and spotted a quick fix:

- fixed `allowed-tools` from YAML array to string format (required for valid frontmatter parsing)

- expanded description with trigger terms like _TDD, regression tests, bug reports, functional coverage_

also added a lightweight GitHub Action that auto-reviews any skill.md changed in a PR (includes min permissions, uses a pinned action version, only posts a review comment).

this means that it gives you and your contributors an instant quality signal before you have to review yourself (no signup, no tokens needed).

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make! happy to answer any questions on the changes.