### PR TITLE
fix(hook): macOS bash 3.2 compatibility (mapfile + empty-array under set -u)

### DIFF
--- a/.github/workflows/test-session-start.yml
+++ b/.github/workflows/test-session-start.yml
@@ -12,7 +12,16 @@ on:
 
 jobs:
   test-hook:
-    runs-on: ubuntu-latest
+    # Run on Linux (bash 5+) AND macOS. macOS ships the system bash 3.2.57
+    # at /bin/bash, which is exactly the environment where the hook used to
+    # fail with "mapfile: command not found". The dedicated bash-3.2 step
+    # below is the regression guard for that class of bug.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout repository
@@ -75,6 +84,53 @@ jobs:
             echo "Warning: Symfony detection may need adjustment"
           fi
 
+      - name: Regression — run under system /bin/bash (macOS = bash 3.2.57)
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "System /bin/bash version:"
+          /bin/bash --version | head -1
+
+          fail=0
+
+          assert_no_shell_error() {
+            # $1 = label, $2 = combined stdout+stderr from running the hook
+            local label="$1" out="$2"
+            if echo "$out" | grep -Eq 'command not found|unbound variable|mapfile'; then
+              echo "::error::[$label] hook emitted a bash 3.2 incompatibility:"
+              echo "$out"
+              fail=1
+            else
+              echo "[$label] OK — no bash 3.2 incompatibility"
+            fi
+          }
+
+          # Case 1: no Symfony app present -> must run clean (no stderr leak)
+          empty_dir="$(mktemp -d)"
+          out="$(cd "$empty_dir" && /bin/bash "$GITHUB_WORKSPACE/hooks/session-start.sh" 2>&1 || true)"
+          assert_no_shell_error "empty-dir" "$out"
+          [[ -z "$out" ]] || { echo "::error::[empty-dir] expected no output, got: $out"; fail=1; }
+
+          # Case 2: Symfony app present -> must emit valid JSON
+          app_dir="$(mktemp -d)"
+          cat > "$app_dir/composer.json" << 'EOF'
+          {
+            "name": "test/symfony-app",
+            "require": { "symfony/framework-bundle": "^7.0" }
+          }
+          EOF
+          mkdir -p "$app_dir/bin" && touch "$app_dir/bin/console"
+          out="$(cd "$app_dir" && /bin/bash "$GITHUB_WORKSPACE/hooks/session-start.sh" 2>&1 || true)"
+          assert_no_shell_error "symfony-app" "$out"
+          if echo "$out" | jq . > /dev/null 2>&1; then
+            echo "[symfony-app] OK — valid JSON under bash 3.2"
+          else
+            echo "::error::[symfony-app] expected valid JSON, got: $out"
+            fail=1
+          fi
+
+          exit "$fail"
+
       - name: Validate hooks.json
         run: |
           echo "Validating hooks.json..."
@@ -97,4 +153,8 @@ jobs:
         run: |
           echo "Checking shell script syntax..."
           bash -n hooks/session-start.sh
+          # Also lint under the macOS system bash 3.2 parser where available
+          if [[ -x /bin/bash ]]; then
+            /bin/bash -n hooks/session-start.sh
+          fi
           echo "Shell syntax is valid!"

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -32,7 +32,12 @@ detect_symfony_apps() {
     -not -path "*/.git/*" \
     -print0 2>/dev/null)
 
-  printf '%s\n' "${apps[@]}"
+  # Guard the empty case: under bash 3.2 + `set -u`, expanding an empty
+  # array as "${apps[@]}" raises "apps[@]: unbound variable" (only fixed in
+  # bash 4.4+). ${#apps[@]} is safe on an empty array, so gate on the count.
+  if [[ ${#apps[@]} -gt 0 ]]; then
+    printf '%s\n' "${apps[@]}"
+  fi
 }
 
 # ============================================
@@ -223,10 +228,15 @@ get_runner_commands() {
 
 main() {
   local cwd="${PWD}"
-  local apps
+  local apps=()
 
   # Detect Symfony applications
-  mapfile -t apps < <(detect_symfony_apps "$cwd")
+  # NOTE: use a read loop instead of `mapfile -t` — mapfile is a bash 4.0+
+  # builtin and macOS ships bash 3.2.57, so mapfile triggers
+  # "mapfile: command not found". This idiom is portable across bash 3.2/4/5.
+  while IFS= read -r app_line; do
+    apps+=("$app_line")
+  done < <(detect_symfony_apps "$cwd")
 
   if [[ ${#apps[@]} -eq 0 ]]; then
     # No Symfony application detected


### PR DESCRIPTION
## Problem

The `SessionStart` hook crashes on macOS with `session-start.sh: line 229: mapfile: command not found`, producing a `SessionStart:startup hook error` on every Claude Code session start on a Mac.

`mapfile`/`readarray` is a **bash 4.0+ builtin**; macOS ships **bash 3.2.57** as the system bash at `/bin/bash`, and `#!/usr/bin/env bash` resolves to it on a stock Mac.

Closes #8.

## Changes

**`hooks/session-start.sh`**
- Replace `mapfile -t apps < <(...)` with a portable `while IFS= read -r` loop — works on bash 3.2, 4 and 5.
- Initialize `local apps=()` and guard `if [[ ${#apps[@]} -gt 0 ]]` before `printf '%s\n' "${apps[@]}"`. Under `set -u` (the script uses `set -euo pipefail`), expanding an empty array as `"${apps[@]}"` raises `apps[@]: unbound variable` on bash < 4.4 — this was a second latent instance of the same class, surfacing whenever the hook runs outside a Symfony project.

**`.github/workflows/test-session-start.yml`** (regression guard — this is why the bug slipped through: CI was Linux-only / bash 5)
- Run the test job on a `[ubuntu-latest, macos-latest]` matrix.
- New step runs the hook under the **system `/bin/bash`** (3.2 on macOS) for both the empty-dir and mock-Symfony cases, and fails on any `command not found` / `unbound variable` / `mapfile` in output.
- `bash -n` lint now also runs under `/bin/bash` where present.

## Verification (local, macOS `/bin/bash` 3.2.57)

```
=== syntax (bash 3.2) ===            OK
=== empty dir ===                    PASS: clean (no stderr leak)
=== symfony dir ===                  PASS: valid JSON
=== unfixed upstream vs new guard === PASS: guard catches the bug
```

The new CI step was confirmed to **fail** against the current (unfixed) script and **pass** against this branch, so it genuinely guards the regression.

## Notes
- No behavior change on Linux — the read-loop and the count guard are equivalent to `mapfile` + unguarded expansion there.
- No new dependencies; pure bash-portability fix.
